### PR TITLE
Fix/cannot use string pattern on byte object

### DIFF
--- a/lib/python/Pyxsim/xe.py
+++ b/lib/python/Pyxsim/xe.py
@@ -69,12 +69,9 @@ class Xe:
         symtab = {}
         for line in stdout:
             line = str(line, "utf8")
-            if line == "":
-                break
             m = re.match(
                 r"Loadable.*for (.*) \(node \"(\d*)\", tile (\d*)", line
             )
-
             if m:
                 current_tile = m.groups(0)[0]
             m = re.match(


### PR DESCRIPTION
Fix a bug where a regex match is attempted against a byte-like object.