### PR TITLE
Edit setup.py to allow pip install -e .

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ import setuptools
 # The same modules should appear in the requirements.txt file as given below.
 setuptools.setup(
     name="test_support",
+    package_dir={'': 'lib/python'},
     packages=setuptools.find_packages(),
     install_requires=[
         "black",


### PR DESCRIPTION
This points the setup.py script to ./lib/python/* as the container for the enclosed Python modules.
After this, installing the package with "pip install -e <path>" then allows the use of
```
import xcoverage
import Pyxsim
```
in test scripts.