### PR TITLE
Added cmake support & assertive comparison tester

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ dkms.conf
 *.*~
 *~
 *.swp
+**/__pycache__/
+test_support.egg-info/
 
 # Others
 *.DS_Store

--- a/lib/python/Pyxsim/__init__.py
+++ b/lib/python/Pyxsim/__init__.py
@@ -119,20 +119,31 @@ def _build(
 
 def run_on_simulator_(xe, tester=None, simthreads=[], **kwargs):
 
-    do_xe_prebuild = kwargs.get("do_xe_prebuild", False)
+    do_xe_prebuild = kwargs.pop("do_xe_prebuild", False)
     capfd = kwargs.pop("capfd", None)
 
     if do_xe_prebuild:
-        build_env = kwargs.get("build_env", {})
-        do_clean = kwargs.get("clean_before_build", False)
-        build_success, build_output = _build(xe, env=build_env, do_clean=do_clean)
+        build_env = kwargs.pop("build_env", {})
+        build_config = kwargs.pop("build_config", None)
+        do_clean = kwargs.pop("clean_before_build", False)
+        binary_child = kwargs.pop("binary_child", None)
+        clean_only = kwargs.pop("clean_only", False)
+        silent = kwargs.pop("silent", None)
+        cmake = kwargs.pop("cmake", None)
+        build_options = kwargs.pop("build_options", None)
+
+        build_success, build_output = _build(xe,
+                                             build_config=build_config,
+                                             env=build_env,
+                                             do_clean=do_clean,
+                                             clean_only=clean_only,
+                                             build_options=build_options,
+                                             cmake=cmake,
+                                             binary_child=binary_child,
+                                             silent=silent)
 
         if not build_success:
             return False
-
-    for k in ["do_xe_prebuild", "build_env", "clean_before_build"]:
-        if k in kwargs:
-            kwargs.pop(k)
 
     run_with_pyxsim(xe, simthreads, **kwargs)
 
@@ -209,7 +220,6 @@ def run_with_pyxsim(
     p.start()
     p.join(timeout=timeout)
     if p.is_alive():
-        assert 0 # Why is this here? Following two lines become unreachable
         sys.stderr.write("Simulator timed out\n")
         p.terminate()
 

--- a/lib/python/Pyxsim/__init__.py
+++ b/lib/python/Pyxsim/__init__.py
@@ -130,7 +130,7 @@ def run_on_simulator_(xe, tester=None, simthreads=[], **kwargs):
         clean_only = kwargs.pop("clean_only", False)
         silent = kwargs.pop("silent", None)
         cmake = kwargs.pop("cmake", None)
-        build_options = kwargs.pop("build_options", None)
+        build_options = kwargs.pop("build_options", [])
 
         build_success, build_output = _build(xe,
                                              build_config=build_config,

--- a/lib/python/Pyxsim/pyxsim.py
+++ b/lib/python/Pyxsim/pyxsim.py
@@ -22,13 +22,16 @@ from Pyxsim.xmostest_subprocess import platform_is_windows
 
 ALL_BITS = 0xFFFFFF
 
+xcc_exec_prefix = os.environ["XCC_EXEC_PREFIX"]
+xcc_exec_prefix += "/" if not xcc_exec_prefix.endswith("/") else ""
+
 if platform_is_windows():
     xsi_lib_path = os.path.abspath(
-        os.environ["XCC_EXEC_PREFIX"] + "../lib/xsidevice.dll"
+        xcc_exec_prefix + "../lib/xsidevice.dll"
     )
 else:
     xsi_lib_path = os.path.abspath(
-        os.environ["XCC_EXEC_PREFIX"] + "../lib/libxsidevice.so"
+        xcc_exec_prefix + "../lib/libxsidevice.so"
     )
 
 xsi_lib = cdll.LoadLibrary(xsi_lib_path)

--- a/lib/python/Pyxsim/testers.py
+++ b/lib/python/Pyxsim/testers.py
@@ -2,6 +2,7 @@
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 import re
 import sys
+from typing import Optional, Sequence, Union
 
 
 class TestError(Exception):
@@ -136,3 +137,116 @@ class ComparisonTester:
             sys.stderr.write("Fail\n")
 
         return self.result
+
+class AssertiveComparisonTester:
+    """
+    This tester uses assert statements rather than printing errors; it will 
+    compare output against a file or list of strings and pass the test if 
+    the output matches.
+    There are 5 failure modes: the output is longer than expected, shorter than
+    expected, does not contain an expected line, contains an unexpected line, or
+    contains all expected lines but in an incorrect order (if ordered is True).
+
+     :param golden:     The expected data to compare the output against.
+                        Should be either a path to a file to read or a list of strings.
+     :param regexp:     A bool that controls whether the expect lines are 
+                        treated as regular expressions or not.
+     :param ordered:    A bool that determines whether the expected input needs
+                        to be matched in an ordered manner or not.
+     :param ignore:     A list of regular expressions to ignore. If 
+                        suppress_multidrive_messages is set to True, this will
+                        be in addition to these.
+     :param suppress_multidrive_messages:
+                        A bool that determines whether lines beginning with
+                        'Internal control pad and plugin driving in opposite 
+                        directions' should be ignored. Defaults to True.
+    """
+
+    def __init__(self,
+                 golden: Union[str, Sequence[str]],
+                 regexp: bool,
+                 ordered: bool,
+                 ignore: Optional[Sequence[str]] = None,
+                 suppress_multidrive_messages: bool = True
+        ) -> None:
+        self._golden = golden
+        self._regexp = regexp
+        self._ordered = ordered
+        self._ignore = ignore
+        self._smm = suppress_multidrive_messages
+
+    def run(self, capture: Union[str, Sequence[str]]):
+        regexp = self._regexp
+        ordered = self._ordered
+        ignore = self._ignore
+        golden = self._golden
+
+        if type(golden) == str:
+            with open(self._golden) as golden:
+                expected = [x.strip() for x in golden.readlines()]
+        else: 
+            expected = [x.strip() for x in golden]
+        
+        if expected:
+            if expected[0].strip() == "":
+                expected = expected[1:]
+        if expected:
+            if expected[-1].strip() == "":
+                expected = expected[:-1]
+
+        # Apply filtering
+
+        if self._smm:
+            capture = [x for x in capture if not x.startswith("Internal control pad and plugin driving in opposite directions")]
+        if ignore:
+            for pattern in ignore:
+                capture = [x for x in capture if not re.search(pattern, x)]
+        if capture:
+            if capture[0].strip() == "":
+                capture = capture[1:]
+        if capture:
+            if capture[-1].strip() == "":
+                capture = capture[:-1]
+
+        # The essential principle here is that we don't want to loop over the 
+        # data again until we really can't avoid it any longer.
+        
+        # Test that the capture is not too short
+        assert len(capture) >= len(expected), f"Length of output ({len(capture)} lines) less than expected ({len(expected)} lines) \n{capture} \n{expected}"
+        
+        # Test that the capture is not too long
+        assert len(capture) <= len(expected), f"Length of output ({len(capture)} lines) greater than expected ({len(expected)} lines) \n{capture} \n{expected}"
+
+
+        if not regexp and not ordered:
+            # If the output and expected do not need to match as regexps, and we
+            # don't care about order, then simple set comparison
+            # can determine unexpected lines/absences in the output
+
+            # Test that the capture contains all expected lines
+            assert set(capture) >= set(expected), f"Output does not contain all expected lines \n Missing: {expected - capture}"
+
+            # Test that the capture does not contain an unexpected line
+            assert set(capture) <= set(expected), f"Output contains unexpected lines \n Contains: {capture - expected}"
+        
+        else:
+            # Otherwise, we need to loop over the whole dataset. 
+            # Let's handle ordered and unordered cases separately.
+            if ordered:
+                # We know that the two lists are the same length, so we can zip
+                # them together to analyse line by line.
+                for l_num, (c_val, e_val) in enumerate(zip(capture, expected)):
+                    if regexp:
+                        assert re.match("^" + e_val + "$", c_val), f"Output ({c_val}) does not match expected regex ({e_val}) at line {l_num}"
+                    else:
+                        assert e_val == c_val, f"Output ({c_val}) does not match expected ({e_val}) at line {l_num}"
+            else:
+                # We're unordered and we know that regexp must be True.
+                # We therefore require that for every line in capture there
+                # exists at least one line in expected that matches.
+                for c_val in capture:
+                    assert any(re.match(e_val, c_val) for e_val in expected), f"Cannot find regex match for output ({c_val})"
+                # And that for every line in expected there exists at least one 
+                # line in capture that matches (these are two different things!)
+                for e_val in expected:
+                    assert any(re.match(e_val, c_val) for c_val in capture), f"Cannot find regex match for expectation ({e_val})"


### PR DESCRIPTION
Earlier work fell behind develop, so existing work has been reworked to match
the emerging style and direction of the repository.

In _build(...), specifying `cmake` now changes behaviour; a
key assumption is that CMakeLists.txt exists
in a superdirectory of the xe_path, and that directory also holds /bin/.

do_run_pyxsim now supports plugins of class XsiPlugin.

pyxsim.py is now guarded against XCC_EXEC_PREFIXes that do not end in /

AssertiveComparisonTester has been added;
this is used in essentially the same way as ComparisonTester, but
uses asserts rather than writing errors to stdout.
Should be more useful for pytest-based frameworks.
Personal opinion is that it's also more readable but that's by the by.

QUESTIONS:
 - If we use run_on_simulator as the main point of entry, when it runs _build there are a couple of options it doesn't pass through (clean_only, build_options, and the new cmake, binary_child, silent). Should these be passed through by popping kwargs, similarly to how build_env and do_clean are?)