### PR TITLE
Fix Auto-Format CI

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -1,5 +1,7 @@
 name: Auto-format
-on: [push, pull_request]
+on:
+  issue_comment:
+    types: [created]
 jobs:
   apply-formatting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
xaction_format runs when commands such as `\format` are commented on a PR, so the trigger should be:

``` yml
on:
  issue_comment:
    types: [created]
```

This should fix the CI error in https://github.com/xmos/test_support/pull/40.