### PR TITLE
Pyxsim cmake build

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 test_support Change Log
 =======================
 
+UNRELEASED
+----------
+
+  * CHANGED:   Pyxsim CMake build uses XCommon CMake
+
 2.0.0
 -----
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,10 @@
-@Library('xmos_jenkins_shared_library@v0.16.4') _
+@Library('xmos_jenkins_shared_library@v0.33.0') _
 
 getApproval()
 
 pipeline {
   agent {
-    label 'x86_64 && brew'
+    label 'x86_64 && linux'
   }
   environment {
     REPO = 'test_support'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-# python_version 3.7.6
+# python_version 3.12.1
+# pip_version 24.2
 #
 # The parse_version_from_requirements() function in the installPipfile.groovy
 # file of the Jenkins Shared Library uses the python_version comment to set
@@ -16,7 +17,6 @@
 # procedure to set up a suitable python environment for that repository may
 # pip-install this one as editable using this repository's setup.py file.  The
 # same modules should appear in the setup.py list as given below.
-black==21.9b0
 
 # Development dependencies
 #
@@ -30,5 +30,4 @@ black==21.9b0
 # If this repository uses the setup functionality (e.g., script entry points)
 # of its own setup.py file, then this list must include an entry for that
 # setup.py file, e.g., '-e .' or '-e ./python' (without the quotes).
--e ../infr_scripts_py
 -e .

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 XMOS LIMITED.
+# Copyright 2020-2024 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 import setuptools
 
@@ -13,8 +13,4 @@ setuptools.setup(
     name="test_support",
     package_dir={"": "lib/python"},
     packages=setuptools.find_packages(),
-    install_requires=[
-        "black",
-    ],
-    dependency_links=[],
 )


### PR DESCRIPTION
The existing cmake build code in Pyxsim was written for standard cmake apps, but this isn't used by any of our repositories, so I've replaced it with something that is compatible with XCommon CMake. The logic of the non-cmake build is intended to be unchanged.