### PR TITLE
Remove flash info from .xn files

### DIFF
--- a/examples/code_coverage/config/XK_XVF3510_L71.xn
+++ b/examples/code_coverage/config/XK_XVF3510_L71.xn
@@ -88,7 +88,7 @@
   </Links>
 
   <ExternalDevices>
-    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash0" Type="0" PageSize="256" SectorSize="4096" NumPages="8192">
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash0">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS_0"/>
       <Attribute Name="PORT_SQI_SCLK" Value="PORT_SQI_SCLK_0"/>
       <Attribute Name="PORT_SQI_SIO" Value="PORT_SQI_SIO_0"/>


### PR DESCRIPTION
From [LSM-105](https://xmosjira.atlassian.net/browse/LSM-105)

Since XTC 15.2.1, we use SFDP to get information about the flash chip on the board, so including this information in the .xn files is no longer necessary. This PR removes that information from those files so tools like xflash don't give warnings that this information is present.

[LSM-105]: https://xmosjira.atlassian.net/browse/LSM-105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ