### PR TITLE
Add verbosity to comparison checker

### DIFF
--- a/lib/python/Pyxsim/testers.py
+++ b/lib/python/Pyxsim/testers.py
@@ -24,14 +24,15 @@ class ComparisonTester:
     This tester will compare ouput against a file and pass a test if
     the output matches
 
-     :param golden:   The expected data to compare the output against.
-                      Can be a list of strings, a string split on new lines,
-                      or a file to read.
-     :param regexp:   A bool that controls whether the expect lines are treated
-                      as regular expressions or not.
-     :param ignore:   A list of regular expressions to ignore
-     :param ordered:  A bool that determines whether the expected input needs
-                      to be matched in an ordered manner or not.
+     :param golden:     The expected data to compare the output against.
+                        Can be a list of strings, a string split on new lines,
+                        or a file to read.
+     :param regexp:     A bool that controls whether the expect lines are treated
+                        as regular expressions or not.
+     :param ignore:     A list of regular expressions to ignore
+     :param ordered:    A bool that determines whether the expected input needs
+                        to be matched in an ordered manner or not.
+     :param verbosity:  An int that determines verbosity level
     """
 
     def __init__(
@@ -40,11 +41,13 @@ class ComparisonTester:
         regexp=False,
         ignore=[],
         ordered=True,
+        verbosity=0,
     ):
         self._golden = golden
         self._regexp = regexp
         self._ignore = ignore
         self._ordered = ordered
+        self._verbosity = verbosity
         self.result = None
         self.failures = []
 
@@ -59,6 +62,7 @@ class ComparisonTester:
     def run(self, output):
         golden = self._golden
         regexp = self._regexp
+        expected = []
         if isinstance(golden, list):
             expected = [x.strip() for x in golden]
         elif isinstance(golden, str):
@@ -85,15 +89,29 @@ class ComparisonTester:
                 continue
             line_num += 1
 
+            try:
+                expected_line = expected[line_num]
+            except IndexError:
+                # Golden file is shorter than output
+                expected_line = "<no line>"
+
+            if self._verbosity > 0:
+                print(f"GOLDEN: {expected_line}")
+                print(f"OUTPUT: {line}")
+
             if line_num >= num_expected:
                 self.record_failure("Length of expected output less than output")
-                break
+
+                if self._verbosity == 0:
+                    # When not in verbose mode, fail immediately
+                    # In verbose mode keep printing out all of the remaining output to assist with debugging
+                    break
 
             if self._ordered:
                 if regexp:
-                    match = re.match(expected[line_num] + "$", line.strip())
+                    match = re.match(expected_line + "$", line.strip())
                 else:
-                    match = expected[line_num] == line.strip()
+                    match = expected_line == line.strip()
 
                 if not match:
                     self.record_failure(
@@ -104,7 +122,7 @@ class ComparisonTester:
                         )
                         % (
                             line_num,
-                            expected[line_num].strip(),
+                            expected_line.strip(),
                             line.strip(),
                         )
                     )


### PR DESCRIPTION
In order to attempt to make `ComparisonTester` a bit more friendly when debugging - and avoid copying the printing code everywhere (like this https://github.com/xmos/lib_gpio/blob/develop/tests/helpers.py) - I have added a `verbosity` param to the constructor. 
 
This is an `int` (rather than `bool`) -  so we can directly wire it up to verbosity of `pytest` (so we dont have to change test code to get more debug info out) e.g. 
 
```
@pytest.fixture
def verbosity(pytestconfig):
    return (pytestconfig.getoption("verbose") or 0)
```

usage: 

```
testPrayForPass(verbosity):

    ...

    tester = testers.ComparisonTester(open(expected_file), regexp=True, ordered=False, verbosity=verbosity)`
  
   pytest.run_on_simulator(.... tester=tester... )

```
 
then 
 
`pytest` still gives stuff like
 
```
test_output.py:41: AssertionError
ERROR: Line 11 of output not found in expected
  Actual  : Checker complete
Fail
```

and `pytest -v ` gives more verbose output like

```
GOLDEN: Checker complee
OUTPUT: Checker complete
-------------------------------------------- Captured stderr call -------------
ERROR: Line 11 of output not found in expected
  Actual  : Checker complete
Fail
```

Its only a relatively small change here: https://github.com/xmos/test_support/pull/52
 
I'm sure we can pretty the output a bit, but be nice to have it used from one place - if it meets peoples requirements?
 
If people could check it/review it that would be super - put "everyone" on review as its quite a common area of complaint and just to let people make people aware of it really