### PR TITLE
Use fork multiprocessing context on Unix to fix pytest capture

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,9 +4,10 @@ test_support Change Log
 UNRELEASED
 ----------
 
+  * ADDED:     Methods in Xsi class for getting the xsim tick frequency
   * CHANGED:   Pyxsim CMake build uses XCommon CMake
   * CHANGED:   The way time is incremented by time_step for better floating point precision
-  * ADDED:     Methods in Xsi class for getting the xsim tick frequency
+  * FIXED:     Resolved issues with stdout/stderr capture in Pyxsim
 
 2.0.0
 -----

--- a/examples/code_coverage/code_coverage.py
+++ b/examples/code_coverage/code_coverage.py
@@ -1,4 +1,4 @@
-# Copyright 2022 XMOS LIMITED.
+# Copyright 2022-2026 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 from xcoverage.xcov import *
 import subprocess as ps

--- a/examples/code_coverage/src/main.xc
+++ b/examples/code_coverage/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2016-2022 XMOS LIMITED.
+// Copyright 2016-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <platform.h>
 #include <print.h>

--- a/examples/pyxsim/example_pyxsim.py
+++ b/examples/pyxsim/example_pyxsim.py
@@ -1,4 +1,4 @@
-# Copyright 2025 XMOS LIMITED.
+# Copyright 2025-2026 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 from pathlib import Path
 

--- a/examples/pyxsim/src/main.c
+++ b/examples/pyxsim/src/main.c
@@ -1,4 +1,4 @@
-// Copyright 2025 XMOS LIMITED.
+// Copyright 2025-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <print.h>
 #include <xcore/port.h>

--- a/lib/python/Pyxsim/__init__.py
+++ b/lib/python/Pyxsim/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2025 XMOS LIMITED.
+# Copyright 2016-2026 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 """
 Pyxsim pytest framework
@@ -166,6 +166,14 @@ def run_with_pyxsim(
     instTracing=False,
     vcdTracing=False,
 ):
+
+    # Use 'fork' on Unix-like systems to preserve stdout/stderr capture
+    # Windows continues to use default 'spawn' method
+    if sys.platform != 'win32':
+        ctx = multiprocessing.get_context('fork')
+    else:
+        ctx = multiprocessing.get_context()
+
     if instTracing or vcdTracing:
 
         log_dir = "logs"
@@ -200,7 +208,7 @@ def run_with_pyxsim(
 
         simargs += ["--vcd-tracing", vcd_args]
 
-    p = multiprocessing.Process(
+    p = ctx.Process(
         target=do_run_pyxsim, args=(xe_path, simargs, appargs, simthreads, plugins)
     )
     p.start()

--- a/lib/python/Pyxsim/pyxsim.py
+++ b/lib/python/Pyxsim/pyxsim.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2024 XMOS LIMITED.
+# Copyright 2016-2026 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 from ctypes import (

--- a/lib/python/Pyxsim/testers.py
+++ b/lib/python/Pyxsim/testers.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2025 XMOS LIMITED.
+# Copyright 2016-2026 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 import re
 import sys

--- a/lib/python/Pyxsim/xe.py
+++ b/lib/python/Pyxsim/xe.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 XMOS LIMITED.
+# Copyright 2016-2026 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 from math import gcd
 from xml.dom.minidom import parse

--- a/lib/python/Pyxsim/xmostest_subprocess.py
+++ b/lib/python/Pyxsim/xmostest_subprocess.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 XMOS LIMITED.
+# Copyright 2016-2026 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 import errno
 import multiprocessing

--- a/lib/python/xcoverage/__init__.py
+++ b/lib/python/xcoverage/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 XMOS LIMITED.
+# Copyright 2016-2026 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 from . import xcov

--- a/lib/python/xcoverage/xcov.py
+++ b/lib/python/xcoverage/xcov.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 XMOS LIMITED.
+# Copyright 2016-2026 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 import os
 import shutil

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 XMOS LIMITED.
+# Copyright 2020-2026 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 import setuptools
 


### PR DESCRIPTION
Configure multiprocessing to use 'fork' method on Unix-like systems instead of default 'spawn' to preserve stdout/stderr file descriptors for pytest capture functionality.