### PR TITLE
Feat/checker verbosity

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ UNRELEASED
   * ADDED:     Methods in Xsi class for getting the xsim tick frequency
   * CHANGED:   Pyxsim CMake build uses XCommon CMake
   * CHANGED:   The way time is incremented by time_step for better floating point precision
+  * CHANGED:   ComparisonChecker only prints expected output when verbosity is 2 or higher (i.e.
+    -vv)
   * FIXED:     Resolved issues with stdout/stderr capture in Pyxsim
   * FIXED:     Subprocess exit code checking in Pyxsim to properly report errors from
     failed commands

--- a/lib/python/Pyxsim/testers.py
+++ b/lib/python/Pyxsim/testers.py
@@ -108,8 +108,9 @@ class ComparisonTester:
                 # Golden file is shorter than output
                 expected_line = "<no line>"
 
-            if self._verbosity > 0:
+            if self._verbosity > 1:
                 print(f"GOLDEN: {expected_line}")
+            if self._verbosity > 0:
                 print(f"OUTPUT: {line}")
 
             if line_num >= num_expected:


### PR DESCRIPTION
ComparisonChecker only prints expected output when verbosity > 1

so with the intended usage, -v gives: 

```
OUTPUT: CONTROLLER START condition
OUTPUT: CONTROLLER Sending direct CCC 0x90 to device 0x3C
OUTPUT: CONTROLLER Broadcast address 0x7E-W |byte: 0xFC|
OUTPUT: CONTROLLER Sending data 0xFC
...
```

-vv gives:

```
GOLDEN: CONTROLLER START condition
OUTPUT: CONTROLLER START condition
GOLDEN: CONTROLLER Sending direct CCC 0x90 to device 0x3C
OUTPUT: CONTROLLER Sending direct CCC 0x90 to device 0x3C
GOLDEN: CONTROLLER Broadcast address 0x7E-W |byte: 0xFC|
OUTPUT: CONTROLLER Broadcast address 0x7E-W |byte: 0xFC|
GOLDEN: CONTROLLER Sending data 0xFC
OUTPUT: CONTROLLER Sending data 0xFC
...
```


